### PR TITLE
54198226 fix migrations 8 and 9

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -45,7 +45,7 @@ GIT
 PATH
   remote: .
   specs:
-    lims-laboratory-app (1.8.0)
+    lims-laboratory-app (1.8.1)
 
 GEM
   remote: http://rubygems.org/

--- a/db/migrations/008_add_unique_constraint_to_labels_table.rb
+++ b/db/migrations/008_add_unique_constraint_to_labels_table.rb
@@ -1,7 +1,7 @@
 ::Sequel.migration do
   change do
     alter_table(:labels) do
-      add_unique_constraint [:labellable_id, :position]
+      add_index [:labellable_id, :position], :unique => true
     end
   end
 end

--- a/db/migrations/009_add_unique_constraint_to_tube_rack_slots_table.rb
+++ b/db/migrations/009_add_unique_constraint_to_tube_rack_slots_table.rb
@@ -2,7 +2,7 @@
   change do
     alter_table(:tube_rack_slots) do
       # A tube can appear in no more than one tube_rack
-      add_unique_constraint :tube_id
+      add_index :tube_id, :unique => true
     end
   end
 end

--- a/lib/lims-laboratory-app/version.rb
+++ b/lib/lims-laboratory-app/version.rb
@@ -1,5 +1,5 @@
 module Lims
   module LaboratoryApp
-    VERSION = "1.8.0"
+    VERSION = "1.8.1"
   end
 end


### PR DESCRIPTION
Using add_unique_constraint results in en error like:
Error: Sequel::DatabaseError: Mysql2::Error: Incorrect index name 'tube_id'
with MySQL. Fix using add_index with the attribute :unique=>true
