### PR TITLE
Fix migration for jruby deployment

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -46,7 +46,7 @@ GIT
 PATH
   remote: .
   specs:
-    lims-laboratory-app (3.1.0.1.0)
+    lims-laboratory-app (3.1.0.1.1)
 
 GEM
   remote: http://rubygems.org/

--- a/db/migrations/013_change_serialize_column_to_json.rb
+++ b/db/migrations/013_change_serialize_column_to_json.rb
@@ -1,4 +1,5 @@
 require 'common'
+require 'lims-core/helpers'
 
 ::Sequel.migration do
   up do

--- a/lib/lims-laboratory-app/version.rb
+++ b/lib/lims-laboratory-app/version.rb
@@ -8,6 +8,7 @@ module Lims
     #
     MINOR_DEV = %{
     --llh1
+    x
     --ke4
     --mb14
     }


### PR DESCRIPTION
Without requiring lims-core/helpers, the migration fails on the dev server with jruby 1.7.5 and Oracle jdk 1.7.
