### PR TITLE
61647818 remove unneeded require form labellable resource

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -46,7 +46,7 @@ GIT
 PATH
   remote: .
   specs:
-    lims-laboratory-app (3.4.0.5.0)
+    lims-laboratory-app (3.4.0.5.1)
 
 GEM
   remote: http://rubygems.org/

--- a/lib/lims-laboratory-app/labels/labellable/labellable_resource.rb
+++ b/lib/lims-laboratory-app/labels/labellable/labellable_resource.rb
@@ -1,4 +1,3 @@
-require 'lims-laboratory-app/laboratory/container/receptacle'
 require 'lims-api/core_resource'
 require 'lims-api/struct_stream'
 

--- a/lib/lims-laboratory-app/version.rb
+++ b/lib/lims-laboratory-app/version.rb
@@ -9,6 +9,7 @@ module Lims
     MINOR_DEV = %{
     --llh1
     --ke4
+    x
     --mb14
     }
 


### PR DESCRIPTION
There is an unneeded require statement in labellable_resource (require 'lims-laboratory-app/laboratory/container/receptacle'), which is causing problem when using labels in other applications.
We can safely remove the require, which is not needed, anyway.

Travis build passed.
