### PR TITLE
active_support gem not available anymore

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 rvm:
-  - "1.9.3"
+  - "1.9.3-p484"
 
 before_install: gem install bundler
 

--- a/Gemfile
+++ b/Gemfile
@@ -4,9 +4,9 @@ source 'http://rubygems.org'
 gemspec
 
 gem 'sinatra', :git => 'http://github.com/sinatra/sinatra.git', :branch => '459369eb66224836f72e21bbece58c007f3422fa'
-gem 'lims-core', '~>3.2.0.rc1', :git => 'http://github.com/sanger/lims-core.git' , :branch => 'uat'
+gem 'lims-core', '~>3.2.1.rc1', :git => 'http://github.com/sanger/lims-core.git' , :branch => 'uat'
 #gem 'lims-core', :path => '../lims-core'
-gem 'lims-api', '~>3.2.1.rc1', :git => 'http://github.com/sanger/lims-api.git' , :branch => 'uat'
+gem 'lims-api', '~>3.2.2.rc1', :git => 'http://github.com/sanger/lims-api.git' , :branch => 'uat'
 #gem 'lims-api', :path => '../lims-api'
 gem 'lims-exception-notifier-app', '~>0.1', :git => 'http://github.com/sanger/lims-exception-notifier-app.git', :branch => 'master'
 #gem 'lims-exception-notifier-app', :path => '../lims-exception-notifier-app'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,10 +1,10 @@
 GIT
   remote: http://github.com/sanger/lims-api.git
-  revision: 2693cd249cea8fa30984f26924f9654d97857a41
+  revision: e487eaa632c95d1048d737a105b484a6a22788a6
   branch: uat
   specs:
-    lims-api (3.2.1.rc1)
-      active_support
+    lims-api (3.2.2.rc1)
+      activesupport
       bunny (= 0.9.0.pre10)
       json
       sequel
@@ -12,11 +12,11 @@ GIT
 
 GIT
   remote: http://github.com/sanger/lims-core.git
-  revision: 586d2d6075d819957522bf09d6ad0c789660f325
+  revision: da083bba6950830ff7456bb7d3e2302180cb39f4
   branch: uat
   specs:
-    lims-core (3.2.0.rc1)
-      active_support
+    lims-core (3.2.1.rc1)
+      activesupport
       aequitas
       bunny (= 0.9.0.pre10)
       dm-validations
@@ -54,13 +54,11 @@ GIT
 PATH
   remote: .
   specs:
-    lims-laboratory-app (3.7.0.rc1)
+    lims-laboratory-app (3.7.1.rc1)
 
 GEM
   remote: http://rubygems.org/
   specs:
-    active_support (3.0.0)
-      activesupport (= 3.0.0)
     activesupport (3.0.0)
     addressable (2.3.6)
     aequitas (0.0.2)
@@ -90,7 +88,7 @@ GEM
     jruby-rack (1.1.13.2)
     json (1.8.1)
     json (1.8.1-java)
-    macaddr (1.6.7)
+    macaddr (1.7.1)
       systemu (~> 2.6.2)
     modularity (0.6.1)
     mustache (0.99.5)
@@ -116,7 +114,7 @@ GEM
     ruby-debug-base (0.10.4-java)
     ruby-graphviz (1.0.9)
     ruby-prof (0.13.0)
-    sequel (4.8.0)
+    sequel (4.16.0)
     sqlite3 (1.3.8)
     state_machine (1.2.0)
     systemu (2.6.4)
@@ -149,8 +147,8 @@ DEPENDENCIES
   hashdiff
   jdbc-mysql
   jdbc-sqlite3
-  lims-api (~> 3.2.1.rc1)!
-  lims-core (~> 3.2.0.rc1)!
+  lims-api (~> 3.2.2.rc1)!
+  lims-core (~> 3.2.1.rc1)!
   lims-exception-notifier-app (~> 0.1)!
   lims-laboratory-app!
   mysql2

--- a/lib/lims-laboratory-app/version.rb
+++ b/lib/lims-laboratory-app/version.rb
@@ -1,5 +1,5 @@
 module Lims
   module LaboratoryApp
-    VERSION = "3.7.0.rc1"
+    VERSION = "3.7.1.rc1"
   end
 end


### PR DESCRIPTION
active_support gem was just an alias to activesupport and the owner yanked it:

http://help.rubygems.org/discussions/suggestions/2747-please-remove-the-active_support-gem
